### PR TITLE
Fixed ext_lookup empty handling

### DIFF
--- a/shcache.lua
+++ b/shcache.lua
@@ -526,29 +526,30 @@ local function load(self, key)
       -- succ: save positive and return the data
       _save_positive(self, key, data, ttl)
       return _return(self, data)
-   else
+   elseif err then
       ngx.log(ngx.WARN, 'external lookup failed: ', err)
+
+      -- external lookup failed
+      -- attempt to load stale data
+      data, flags = _get_stale(self)
+      if data and not _is_empty(data, flags) then
+         -- hit_stale + valid (positive) data
+
+         flags = _save_actualize(self, key, data, flags)
+         -- unlock before de-serializing data
+         _unlock(self)
+         data = _process_cached_data(self, data, flags)
+         return _return(self, data)
+      end
+
+      if DEBUG and data then
+         -- there is data, but it failed _is_empty() => stale negative data
+         print('STALE_NEGATIVE data => cache as a new HIT_NEGATIVE')
+      end
    end
 
-   -- external lookup failed
-   -- attempt to load stale data
-   data, flags = _get_stale(self)
-   if data and not _is_empty(data, flags) then
-      -- hit_stale + valid (positive) data
-
-      flags = _save_actualize(self, key, data, flags)
-      -- unlock before de-serializing data
-      _unlock(self)
-      data = _process_cached_data(self, data, flags)
-      return _return(self, data)
-   end
-
-   if DEBUG and data then
-      -- there is data, but it failed _is_empty() => stale negative data
-      print('STALE_NEGATIVE data => cache as a new HIT_NEGATIVE')
-   end
-
-   -- nothing has worked, save negative and return empty
+   -- either ext_lookup returned an empty value, or it failed and there was no
+   -- stale data. Save negative and return empty
    _save_negative(self, key)
    return _return(self, nil)
 end


### PR DESCRIPTION
The current behavior concerning empty returns from `ext_lookup` seems wrong:
* It logs a WARN level message (already addressed in #2)
* It tries to load stale data

The latter point leads to wrong results when cached data expires and the new lookup succeeds but find out the data does not exist anymore (empty result). In this case, the empty result should be stored as a negative hit.